### PR TITLE
Troubleshoot applitools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,54 +75,113 @@
       }
     },
     "@applitools/eyes-webdriverio": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/@applitools/eyes-webdriverio/-/eyes-webdriverio-5.8.4.tgz",
-      "integrity": "sha512-aKyMrdHR7MZCsiN7NbMvZSpkBpR7XhM5vMVIxenVZ2mlbw39lGK41Kcy4WlAkZHmFnIYaDxl3JpA638l1+Kx5w==",
+      "version": "5.9.11",
+      "resolved": "https://registry.npmjs.org/@applitools/eyes-webdriverio/-/eyes-webdriverio-5.9.11.tgz",
+      "integrity": "sha512-b9RC2dWZKVgJ4Hk/Go0lWU4WvGgKGB8UkKJm8UHGNy1VA+dXDA9VE2gcJDv7tlYUSGehQKuN8dDEmHXIXsDZQg==",
       "dev": true,
       "requires": {
-        "@applitools/dom-utils": "~4.6.38",
-        "@applitools/eyes-sdk-core": "~5.20.2",
-        "@applitools/visual-grid-client": "^13.3.6",
-        "chromedriver": "^78.0.1",
-        "geckodriver": "^1.19.0",
+        "@applitools/dom-utils": "4.7.4",
+        "@applitools/eyes-sdk-core": "6.0.9",
+        "@applitools/visual-grid-client": "13.5.10",
         "selenium-webdriver": "^4.0.0-alpha.5",
-        "webdriverio": "^5.15.3"
+        "webdriverio": "^5.18.6"
       },
       "dependencies": {
-        "@applitools/dom-utils": {
-          "version": "4.6.41",
-          "resolved": "https://registry.npmjs.org/@applitools/dom-utils/-/dom-utils-4.6.41.tgz",
-          "integrity": "sha512-wp7zSlVOzkuK55e5R5FeUwTdxec1ZX+Q6dVCC22vI/D3lA1vOJ7I0tQWcT67pxwZ4BTezmGu9xWRUxnJM6ERqg==",
+        "@applitools/dom-snapshot": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/@applitools/dom-snapshot/-/dom-snapshot-3.2.3.tgz",
+          "integrity": "sha512-bF0nea8bBebJCobO5BVTMTEHR59rnF1FqzmGBlcNp91737pOxzxLG96l0ZfATjHCBEqybADmCdZlFgZJ2q/fTA==",
           "dev": true,
           "requires": {
-            "@applitools/dom-capture": "^7.0.17",
-            "@applitools/eyes-common": "^3.12.2",
-            "axios": "^0.19.0"
+            "@applitools/functional-commons": "^1.5.4"
+          }
+        },
+        "@applitools/eyes-common": {
+          "version": "3.18.2",
+          "resolved": "https://registry.npmjs.org/@applitools/eyes-common/-/eyes-common-3.18.2.tgz",
+          "integrity": "sha512-TdgvuKy+FEmi/KxRIPluwRSt3iH7V/EwkIAdmyd6bJZpmyaHw6KTFP4N12x46hTu7DsAAtAH0iWmF1QHreGDQg==",
+          "dev": true,
+          "requires": {
+            "cosmiconfig": "^6.0.0",
+            "dateformat": "^3.0.3",
+            "debug": "^4.1.1",
+            "deepmerge": "^4.2.2",
+            "png-async": "^0.9.4",
+            "stack-trace": "^0.0.10"
           }
         },
         "@applitools/eyes-sdk-core": {
-          "version": "5.20.7",
-          "resolved": "https://registry.npmjs.org/@applitools/eyes-sdk-core/-/eyes-sdk-core-5.20.7.tgz",
-          "integrity": "sha512-9bDJkU9JbN3N9RoX1ldbUEvTlkjNuyHjp9PT+NlLgdelbkfpdphCn7CmXRyI61db9BrTKPW/9An/88S8lJbRAQ==",
+          "version": "6.0.9",
+          "resolved": "https://registry.npmjs.org/@applitools/eyes-sdk-core/-/eyes-sdk-core-6.0.9.tgz",
+          "integrity": "sha512-IKSRhE/tfT2zzVCP6pPoHBnIdyvciYRFdEKXfIuNLB6uFem/MIf8LsOwDkbTTr3EXxwgLKjqKyVvuHRu0OoJVQ==",
           "dev": true,
           "requires": {
-            "@applitools/eyes-common": "^3.12.2",
-            "axios": "^0.19.0",
-            "es6-promise-pool": "^2.5.0",
+            "@applitools/eyes-common": "3.18.2",
+            "@applitools/isomorphic-fetch": "3.0.0",
+            "axios": "0.19.2",
+            "chalk": "3.0.0",
+            "es6-promise-pool": "2.5.0",
             "tunnel": "0.0.6"
           }
         },
-        "chromedriver": {
-          "version": "78.0.1",
-          "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-78.0.1.tgz",
-          "integrity": "sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==",
+        "@applitools/http-commons": {
+          "version": "2.3.12",
+          "resolved": "https://registry.npmjs.org/@applitools/http-commons/-/http-commons-2.3.12.tgz",
+          "integrity": "sha512-8aajoZQLoJPSljvG5AoCdoSpaun7di8lZ5wH83FoWkYAhIqVHmpE3UTMpFcj9us3NjCK7YH6vqRq7LKQe+mMrw==",
           "dev": true,
           "requires": {
-            "del": "^4.1.1",
-            "extract-zip": "^1.6.7",
+            "@applitools/functional-commons": "^1.5.2",
+            "@applitools/monitoring-commons": "^1.0.15",
+            "agentkeepalive": "^4.0.2",
+            "debug": "^4.1.1",
+            "lodash.merge": "^4.6.2",
+            "node-fetch": "^2.6.0"
+          }
+        },
+        "@applitools/visual-grid-client": {
+          "version": "13.5.10",
+          "resolved": "https://registry.npmjs.org/@applitools/visual-grid-client/-/visual-grid-client-13.5.10.tgz",
+          "integrity": "sha512-iROc0Hy4iahX1oEr/U6MJfwX14KQc7tMbY3zxHPcAjI/mj2l7PgDnmmTHsRzB7mdkIuZjLYu7MnK+S6Opxr2nA==",
+          "dev": true,
+          "requires": {
+            "@applitools/dom-snapshot": "3.2.3",
+            "@applitools/eyes-common": "3.18.2",
+            "@applitools/eyes-sdk-core": "6.0.7",
+            "@applitools/functional-commons": "1.5.4",
+            "@applitools/http-commons": "2.3.12",
+            "@applitools/isomorphic-fetch": "3.0.0",
+            "@applitools/jsdom": "1.0.2",
+            "he": "1.2.0",
+            "lodash.mapvalues": "^4.6.0",
+            "mime-types": "^2.1.24",
             "mkdirp": "^0.5.1",
-            "request": "^2.88.0",
-            "tcp-port-used": "^1.0.1"
+            "postcss-value-parser": "^4.0.2",
+            "throat": "^5.0.0"
+          },
+          "dependencies": {
+            "@applitools/eyes-sdk-core": {
+              "version": "6.0.7",
+              "resolved": "https://registry.npmjs.org/@applitools/eyes-sdk-core/-/eyes-sdk-core-6.0.7.tgz",
+              "integrity": "sha512-O11E6zDFpI78pctUBWj8vrSjnaXoHeI4ciJKqiI+v0rFQp5j/TFK8tHkYp6dlZlGHJX9QwMFF7A0tM7eleCzXQ==",
+              "dev": true,
+              "requires": {
+                "@applitools/eyes-common": "3.18.2",
+                "@applitools/isomorphic-fetch": "3.0.0",
+                "axios": "0.19.2",
+                "chalk": "3.0.0",
+                "es6-promise-pool": "2.5.0",
+                "tunnel": "0.0.6"
+              }
+            }
+          }
+        },
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10"
           }
         }
       }
@@ -260,6 +319,21 @@
             "chalk": "^3.0.0",
             "es6-promise-pool": "^2.5.0",
             "tunnel": "0.0.6"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         }
       }
@@ -634,12 +708,6 @@
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
     },
-    "adm-zip": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
-      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
-      "dev": true
-    },
     "agent-base": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
@@ -933,12 +1001,6 @@
         "readable-stream": "^3.0.1"
       }
     },
-    "bluebird": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-      "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
-      "dev": true
-    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -1159,12 +1221,6 @@
         }
       }
     },
-    "capture-stack-trace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-      "dev": true
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1203,12 +1259,6 @@
         "readdirp": "~3.3.0"
       }
     },
-    "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
-      "dev": true
-    },
     "chromedriver": {
       "version": "79.0.0",
       "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-79.0.0.tgz",
@@ -1220,6 +1270,23 @@
         "mkdirp": "^0.5.1",
         "request": "^2.88.0",
         "tcp-port-used": "^1.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
       }
     },
     "cli-cursor": {
@@ -1453,15 +1520,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
@@ -1647,32 +1705,6 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
-      }
     },
     "easy-table": {
       "version": "1.1.1",
@@ -1958,6 +1990,21 @@
             "ms": "2.0.0"
           }
         },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2189,15 +2236,6 @@
         "universalify": "^0.1.0"
       }
     },
-    "fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-      "dev": true,
-      "requires": {
-        "minipass": "^2.6.0"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2224,19 +2262,6 @@
       "dev": true,
       "requires": {
         "globule": "^1.0.0"
-      }
-    },
-    "geckodriver": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-1.19.1.tgz",
-      "integrity": "sha512-xWL/+eEhQ6+t98rc1c+xVM3hshDJibXtZf9WJA3sshxq4k5L1PBwfmswyBmmlKUfBr4xuC256gLVC2RxFhiCsQ==",
-      "dev": true,
-      "requires": {
-        "adm-zip": "0.4.11",
-        "bluebird": "3.4.6",
-        "got": "5.6.0",
-        "https-proxy-agent": "3.0.0",
-        "tar": "4.4.2"
       }
     },
     "get-caller-file": {
@@ -2299,47 +2324,6 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
-      }
-    },
-    "got": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
-      "integrity": "sha1-ux1+4WO3gIK7yOuDbz85UATqb78=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "^3.0.1",
-        "duplexer2": "^0.1.4",
-        "is-plain-obj": "^1.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "node-status-codes": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "parse-json": "^2.1.0",
-        "pinkie-promise": "^2.0.0",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.5",
-        "timed-out": "^2.0.0",
-        "unzip-response": "^1.0.0",
-        "url-parse-lax": "^1.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "graceful-fs": {
@@ -2465,27 +2449,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
-      "integrity": "sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "humanize-ms": {
@@ -2734,22 +2697,10 @@
         "path-is-inside": "^1.0.2"
       }
     },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
-    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regex": {
@@ -2761,22 +2712,10 @@
         "has": "^1.0.3"
       }
     },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "dev": true
-    },
     "is-running": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-running/-/is-running-2.1.0.tgz",
       "integrity": "sha1-MKc/9cw4VOT8JUkICen1q/jeCeA=",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-symbol": {
@@ -3248,12 +3187,6 @@
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
       "dev": true
     },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true
-    },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -3335,33 +3268,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
-    },
-    "minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
-        }
-      }
-    },
-    "minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "dev": true,
-      "requires": {
-        "minipass": "^2.9.0"
-      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -3488,6 +3394,21 @@
             "path-exists": "^3.0.0"
           }
         },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -3606,12 +3527,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
-    },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
       "dev": true
     },
     "normalize-package-data": {
@@ -3762,9 +3677,9 @@
       "dev": true
     },
     "pako": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
     "parent-module": {
@@ -3922,12 +3837,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
     "pretty-ms": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.1.0.tgz",
@@ -4008,33 +3917,6 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "read-pkg": {
@@ -4332,6 +4214,23 @@
           "dev": true,
           "requires": {
             "pend": "~1.2.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
           }
         },
         "tar-stream": {
@@ -4692,29 +4591,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "tar": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.2.tgz",
-      "integrity": "sha512-BfkE9CciGGgDsATqkikUHrQrraBCO+ke/1f6SFAEMnxyyfN9lxC+nW1NFWMpqH865DhHIy9vQi682gk1X7friw==",
-      "dev": true,
-      "requires": {
-        "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.2.4",
-        "minizlib": "^1.1.0",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
-        }
-      }
-    },
     "tar-stream": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
@@ -4785,12 +4661,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "timed-out": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-      "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
       "dev": true
     },
     "tmp": {
@@ -4935,12 +4805,6 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -4955,15 +4819,6 @@
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
       "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==",
       "dev": true
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^1.0.1"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "@applitools/eyes-selenium": "^4.33.8",
-    "@applitools/eyes-webdriverio": "5.8.4",
+    "@applitools/eyes-webdriverio": "5.9.7",
     "@types/jasmine": "^3.5.1",
     "@wdio/allure-reporter": "^5.18.6",
     "@wdio/browserstack-service": "^5.18.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "@applitools/eyes-selenium": "^4.33.8",
-    "@applitools/eyes-webdriverio": "5.9.7",
+    "@applitools/eyes-webdriverio": "5.9.11",
     "@types/jasmine": "^3.5.1",
     "@wdio/allure-reporter": "^5.18.6",
     "@wdio/browserstack-service": "^5.18.1",

--- a/src/specs/category-applitools.spec.ts
+++ b/src/specs/category-applitools.spec.ts
@@ -15,6 +15,7 @@ import {resolve} from 'path'
   mkdirSync(folder)
   const runner = new ClassicRunner();
   const eyes = new Eyes(runner);
+  eyes.setStitchOverlap(60)
   eyes.setSaveDebugScreenshots(true)
   eyes.setDebugScreenshotsPath(folder)
   const logHandler = new FileLogHandler(true, `${folder}/eyes.log`);

--- a/src/specs/category-applitools.spec.ts
+++ b/src/specs/category-applitools.spec.ts
@@ -2,6 +2,7 @@ import {ClassicRunner,
     Eyes,
     FileLogHandler,
     StitchMode,
+    By,
   Target} from '@applitools/eyes-webdriverio';  
 
   const dateTime = Date.now();
@@ -34,7 +35,7 @@ import {ClassicRunner,
       $('app-header-with-search').scrollIntoView({behavior: 'smooth', block: 'center', inline: 'center'});
       
       browser.call(() => eyes.open(browser, 'Category Page','/medical'));
-      browser.call(() => eyes.check('CategoryFullPage',Target.window().fully()));
+      browser.call(() => eyes.check('CategoryFullPage',Target.window().fully().scrollRootElement(By.css('body'))));
 
     });
   

--- a/src/specs/category-applitools.spec.ts
+++ b/src/specs/category-applitools.spec.ts
@@ -5,18 +5,27 @@ import {ClassicRunner,
     By,
   Target} from '@applitools/eyes-webdriverio';  
 
+import {mkdirSync} from 'fs'
+import {resolve} from 'path'
+
   const dateTime = Date.now();
   const batchInfo =  'category-page-tests' ;
   const batchId = 'category-page-' + '-' + dateTime;
+  const folder = resolve(__dirname, `../../../eyes-logs/${batchId}`)
+  mkdirSync(folder)
   const runner = new ClassicRunner();
   const eyes = new Eyes(runner);
+  eyes.setSaveDebugScreenshots(true)
+  eyes.setDebugScreenshotsPath(folder)
+  const logHandler = new FileLogHandler(true, `${folder}/eyes.log`);
+  logHandler.open()
   
   describe('category-page : tests-applitools :: ', () => {
 
     beforeAll(() => {
       eyes.setMatchLevel('Layout');
       eyes.setStitchMode(StitchMode.CSS);
-      eyes.setLogHandler(new FileLogHandler(true, './eyes-logs/' + batchId + '.log'));
+      eyes.setLogHandler(logHandler);
       eyes.setApiKey(browser.config['APPLITOOLS_API_KEY']);
       eyes.addProperty('Spec', 'category-page.spec');
       if ( process.env.APPLITOOLS_BATCH_NAME === undefined &&  process.env.APPLITOOLS_BATCH_ID === undefined ) {
@@ -38,6 +47,12 @@ import {ClassicRunner,
       browser.call(() => eyes.check('CategoryFullPage',Target.window().fully().scrollRootElement(By.css('body'))));
 
     });
+
+    it('hacker news', () => {
+      browser.url('https://news.ycombinator.com')
+      browser.call(() => eyes.open(browser, 'hacker news', 'front page viewport screnshot'))
+      browser.call(() => eyes.check('', Target.window()))
+    })
   
     afterEach( () => {
       if (browser.call(() =>  eyes.getIsOpen() )) {


### PR DESCRIPTION
The reason 5.9.x malfunctioned is because there was a difference in behavior regarding the hiding of scrollbars.
In order to work with the new behavior on the `/medical` page, we need to set the scroll root element to `body`.